### PR TITLE
Fix start animation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -109,7 +109,7 @@ export default class LevelSelector extends UICorePlugin {
     this.core.getCurrentPlayback().currentLevel = this.selectedLevelId
 
     this.toggleContextMenu()
-    this.render()
+    this.updateText(this.selectedLevelId)
 
     event.stopPropagation()
     return false


### PR DESCRIPTION
Calling ```this.render()``` would recreate DOM elements after the event PLAYBACK_LEVEL_SWITCH_START was handled, so the animation would actually never start.

It's not that pretty to call updateText outside the ```render``` method, but I wouldn't like to turn it into a monster method with conditionals. If you have a better way to do this, just let me know. 