### PR TITLE
chore: change package.json main field to use ES5 dist bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.10",
   "license": "MIT",
   "repository": "clappr/clappr-level-selector-plugin",
-  "main": "index.js",
+  "main": "dist/level-selector.js",
   "scripts": {
     "release": "node_modules/.bin/webpack --progress -d --optimize-minimize --optimize-dedupe --output-filename level-selector.min.js",
     "build": "node_modules/.bin/webpack --progress",


### PR DESCRIPTION
It should fix #57 (_ie: node js require compliance_).
