### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var player = new Clappr.Player({
 *Note: There is a minified version served through CDNs too:*
 ```html
 <script type="text/javascript"
-        src="//cdn.jsdelivr.net/clappr.level-selector/latest/level-selector.min.js"></script>
+        src="//cdn.jsdelivr.net/gh/clappr/clappr-level-selector-plugin@latest/dist/level-selector.min.js"></script>
 ```
 
 ## Compatibility


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/clappr/clappr-level-selector-plugin.

Feel free to ping me if you have any questions regarding this change.