### PR TITLE
Fix labels with multiple words that are divided into more than one line

### DIFF
--- a/src/public/style.scss
+++ b/src/public/style.scss
@@ -27,6 +27,7 @@
     border: 1px solid black;
     display: none;
     background-color: #e6e6e6;
+    white-space: nowrap;
   }
 
   li {


### PR DESCRIPTION
Sometimes, if you have labels with more than one word (eg 'HD 720p' or 'HD 1080p') when selecting any level from the list, those labels are broken on more than one line. I made the correction in css to avoid this problem.

Ps.: My commit does not include the compiled version
