### PR TITLE
fix: restore backward compatibility with Clappr 0.2.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ var player = new Clappr.Player({
 });
 ```
 
+And also transform available levels:
+
+```javascript
+var player = new Clappr.Player({
+  // [...]
+  levelSelectorConfig: {
+    onLevelsAvailable: function(levels) {
+      return levels.reverse(); // For example, reverse levels order
+    },
+  },
+});
+```
+
 *Note: There is a minified version served through CDNs too:*
 ```html
 <script type="text/javascript"

--- a/public/index.html
+++ b/public/index.html
@@ -2,24 +2,30 @@
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <script type="text/javascript" charset="utf-8" src="/latest/clappr.min.js"></script>
+  <!-- <script src="https://cdn.jsdelivr.net/npm/clappr@0.2.100/dist/clappr.min.js"></script> -->
+  <script src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dash-shaka-playback@latest/dist/dash-shaka-playback.min.js"></script>
   <script type="text/javascript" charset="utf-8" src="/latest/level-selector.js"></script>
   <title>clappr-level-selector-plugin Test Page</title>
   <script type="text/javascript" charset="utf-8">
-  window.onload = function() {
-  var player = new Clappr.Player({
-    source: 'http://www.streambox.fr/playlists/test_001/stream.m3u8',
-    parentId: '#player-wrapper',
+  document.addEventListener("DOMContentLoaded", function() {
+    console.log('Clappr version ' + Clappr.version);
 
-    plugins: {
-      core: [LevelSelector],
-    },
+    var player = new Clappr.Player({
+      // source: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
+      source: 'https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd',
+      parentId: '#player-wrapper',
+      plugins: [
+        LevelSelector,
+        DashShakaPlayback,
+      ],
+      width: 640,
+      height: 360,
+      hideMediaControl: false,
+      autoPlay: true
+    });
 
-    width: 640, height: 360,
-    hideMediaControl: false,
-    autoPlay: true
   });
-}
   </script>
 </head>
 <body>

--- a/src/main.js
+++ b/src/main.js
@@ -25,13 +25,13 @@ export default class LevelSelector extends UICorePlugin {
     }
   }
 
-  get __container() {
+  get container() {
     return this.core.activeContainer
       ? this.core.activeContainer
       : this.core.mediaControl.container
   }
 
-  get __playback() {
+  get playback() {
     return this.core.activePlayback
       ? this.core.activePlayback
       : this.core.getCurrentPlayback()
@@ -48,15 +48,15 @@ export default class LevelSelector extends UICorePlugin {
   }
 
   bindPlaybackEvents() {
-    if (!this.__playback) return
+    if (!this.playback) return
 
-    this.listenTo(this.__playback, Events.PLAYBACK_LEVELS_AVAILABLE, this.fillLevels)
-    this.listenTo(this.__playback, Events.PLAYBACK_LEVEL_SWITCH_START, this.startLevelSwitch)
-    this.listenTo(this.__playback, Events.PLAYBACK_LEVEL_SWITCH_END, this.stopLevelSwitch)
-    this.listenTo(this.__playback, Events.PLAYBACK_BITRATE, this.updateCurrentLevel)
+    this.listenTo(this.playback, Events.PLAYBACK_LEVELS_AVAILABLE, this.fillLevels)
+    this.listenTo(this.playback, Events.PLAYBACK_LEVEL_SWITCH_START, this.startLevelSwitch)
+    this.listenTo(this.playback, Events.PLAYBACK_LEVEL_SWITCH_END, this.stopLevelSwitch)
+    this.listenTo(this.playback, Events.PLAYBACK_BITRATE, this.updateCurrentLevel)
 
-    let playbackLevelsAvailableWasTriggered = this.__playback.levels && this.__playback.levels.length > 0
-    playbackLevelsAvailableWasTriggered && this.fillLevels(this.__playback.levels)
+    let playbackLevelsAvailableWasTriggered = this.playback.levels && this.playback.levels.length > 0
+    playbackLevelsAvailableWasTriggered && this.fillLevels(this.playback.levels)
   }
 
   reload() {
@@ -69,11 +69,9 @@ export default class LevelSelector extends UICorePlugin {
   }
 
   shouldRender() {
-    if (!this.__container) return false
+    if (!this.container || !this.playback) return false
 
-    if (!this.__playback) return false
-
-    let respondsToCurrentLevel = this.__playback.currentLevel !== undefined
+    let respondsToCurrentLevel = this.playback.currentLevel !== undefined
     // Only care if we have at least 2 to choose from
     let hasLevels = !!(this.levels && this.levels.length > 1)
 
@@ -96,7 +94,7 @@ export default class LevelSelector extends UICorePlugin {
   fillLevels(levels, initialLevel = AUTO) {
     if (this.selectedLevelId === undefined) this.selectedLevelId = initialLevel
 
-    let onLevelsAvailable = this.core.options.levelSelectorConfig.onLevelsAvailable
+    let onLevelsAvailable = this.core.options && this.core.options.levelSelectorConfig && this.core.options.levelSelectorConfig.onLevelsAvailable
     if (onLevelsAvailable) {
       if (typeof onLevelsAvailable === 'function')
         levels = onLevelsAvailable(levels.slice())
@@ -142,8 +140,8 @@ export default class LevelSelector extends UICorePlugin {
 
   onLevelSelect(event) {
     this.selectedLevelId = parseInt(event.target.dataset.levelSelectorSelect, 10)
-    if (this.__playback.currentLevel == this.selectedLevelId) return false
-    this.__playback.currentLevel = this.selectedLevelId
+    if (this.playback.currentLevel == this.selectedLevelId) return false
+    this.playback.currentLevel = this.selectedLevelId
 
     this.toggleContextMenu()
 

--- a/src/main.js
+++ b/src/main.js
@@ -67,8 +67,8 @@ export default class LevelSelector extends UICorePlugin {
     this.listenTo(this.__playback, Events.PLAYBACK_LEVEL_SWITCH_END, this.stopLevelSwitch)
     this.listenTo(this.__playback, Events.PLAYBACK_BITRATE, this.updateCurrentLevel)
 
-    let playbackLevelsAvaialbeWasTriggered = this.__playback.levels && this.__playback.levels.length > 0
-    playbackLevelsAvaialbeWasTriggered && this.fillLevels(this.__playback.levels)
+    let playbackLevelsAvailableWasTriggered = this.__playback.levels && this.__playback.levels.length > 0
+    playbackLevelsAvailableWasTriggered && this.fillLevels(this.__playback.levels)
   }
 
   reload() {
@@ -174,11 +174,13 @@ export default class LevelSelector extends UICorePlugin {
       this.buttonElement().text(this.findLevelBy(level).label)
 
   }
+
   updateCurrentLevel(info) {
     let level = this.findLevelBy(info.level)
     this.currentLevel = level ? level : null
     this.highlightCurrentLevel()
   }
+
   highlightCurrentLevel() {
     this.levelElement().removeClass('current')
     this.currentLevel && this.levelElement(this.currentLevel.id).addClass('current')

--- a/src/main.js
+++ b/src/main.js
@@ -87,6 +87,7 @@ export default class LevelSelector extends UICorePlugin {
       this.$el.html(this.template({ 'levels':this.levels, 'title': this.getTitle() }))
       this.$el.append(style)
       this.core.mediaControl.$('.media-control-right-panel').append(this.el)
+      this.$('.level_selector ul').css('max-height', this.core.el.offsetHeight*0.8)
       this.highlightCurrentLevel()
     }
     return this

--- a/src/main.js
+++ b/src/main.js
@@ -95,6 +95,15 @@ export default class LevelSelector extends UICorePlugin {
 
   fillLevels(levels, initialLevel = AUTO) {
     if (this.selectedLevelId === undefined) this.selectedLevelId = initialLevel
+
+    let onLevelsAvailable = this.core.options.levelSelectorConfig.onLevelsAvailable
+    if (onLevelsAvailable) {
+      if (typeof onLevelsAvailable === 'function')
+        levels = onLevelsAvailable(levels.slice())
+      else
+        throw new TypeError('onLevelsAvailable must be a function')
+    }
+
     this.levels = levels
     this.configureLevelsLabels()
     this.render()

--- a/src/main.js
+++ b/src/main.js
@@ -47,21 +47,9 @@ export default class LevelSelector extends UICorePlugin {
     this.listenTo(this.core.mediaControl, Events.MEDIACONTROL_HIDE, this.hideSelectLevelMenu)
   }
 
-  unBindEvents() {
-    this.stopListening(this.core, Events.CORE_READY)
-    if (Events.CORE_ACTIVE_CONTAINER_CHANGED)
-      this.stopListening(this.core, Events.CORE_ACTIVE_CONTAINER_CHANGED)
-    else
-      this.stopListening(this.core.mediaControl, Events.MEDIACONTROL_CONTAINERCHANGED)
-    this.stopListening(this.core.mediaControl, Events.MEDIACONTROL_RENDERED)
-    this.stopListening(this.core.mediaControl, Events.MEDIACONTROL_HIDE)
-    this.stopListening(this.__playback, Events.PLAYBACK_LEVELS_AVAILABLE)
-    this.stopListening(this.__playback, Events.PLAYBACK_LEVEL_SWITCH_START)
-    this.stopListening(this.__playback, Events.PLAYBACK_LEVEL_SWITCH_END)
-    this.stopListening(this.__playback, Events.PLAYBACK_BITRATE)
-  }
-
   bindPlaybackEvents() {
+    if (!this.__playback) return
+
     this.listenTo(this.__playback, Events.PLAYBACK_LEVELS_AVAILABLE, this.fillLevels)
     this.listenTo(this.__playback, Events.PLAYBACK_LEVEL_SWITCH_START, this.startLevelSwitch)
     this.listenTo(this.__playback, Events.PLAYBACK_LEVEL_SWITCH_END, this.stopLevelSwitch)
@@ -72,9 +60,12 @@ export default class LevelSelector extends UICorePlugin {
   }
 
   reload() {
-    this.unBindEvents()
-    this.bindEvents()
-    this.bindPlaybackEvents()
+    this.stopListening()
+    // Ensure it stop listening before rebind events (avoid duplicate events)
+    process.nextTick(() => {
+      this.bindEvents()
+      this.bindPlaybackEvents()
+    })
   }
 
   shouldRender() {

--- a/src/public/style.scss
+++ b/src/public/style.scss
@@ -43,7 +43,7 @@
 
     a {
       color: #eee;
-      padding: 5px 10px;
+      padding: 5px 18px;
       display: block;
       text-decoration: none;
 

--- a/src/public/style.scss
+++ b/src/public/style.scss
@@ -22,6 +22,8 @@
   }
 
   &> ul {
+    overflow-x: hidden;
+    overflow-y: auto;
     list-style-type: none;
     position: absolute;
     bottom: 100%;


### PR DESCRIPTION
Fix backward compatibility with Clappr 0.2.X.

Fix a minor issue with some events trigger twice while reloading ui.

Added Dash shaka playback plugin in dev. test page to ease future debug.

PS: some "chore" improvement could be also to remove Clappr from dev dependencies. _(now loaded from jsDelivr on test page)_